### PR TITLE
feat: support nested unions

### DIFF
--- a/src/graphqlGenerator.test.ts
+++ b/src/graphqlGenerator.test.ts
@@ -505,6 +505,81 @@ describe('generateGraphQL', () => {
     `)
   })
 
+  it('should compile nested unions', async () => {
+    const graphql = await compileSchema({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      title: 'Parking lot',
+      additionalProperties: false,
+      properties: {
+        vehicles: {
+          type: 'array',
+          items: { $ref: '#/$defs/vehicle' },
+        },
+      },
+      $defs: {
+        vehicle: {
+          type: 'object',
+          title: 'Vehicle',
+          oneOf: [{ $ref: '#/$defs/car' }, { $ref: '#/$defs/bike' }],
+        },
+        car: {
+          type: 'object',
+          title: 'Car',
+          oneOf: [{ $ref: '#/$defs/normalCar' }, { $ref: '#/$defs/lorry' }],
+        },
+        normalCar: {
+          type: 'object',
+          title: 'NormalCar',
+          additionalProperties: false,
+          properties: {
+            numberOfPassengers: { type: 'integer' },
+            model: { type: 'string' },
+          },
+        },
+        lorry: {
+          type: 'object',
+          title: 'Lorry',
+          additionalProperties: false,
+          properties: {
+            maxLoad: { type: 'number' },
+            model: { type: 'string' },
+          },
+        },
+        bike: {
+          type: 'object',
+          title: 'Bike',
+          additionalProperties: false,
+          properties: {
+            numberOfWheels: { type: 'integer' },
+          },
+          required: ['numberOfWheels'],
+        },
+      },
+    })
+    expect(graphql).toMatchInlineSnapshot(`
+      "type ParkingLot {
+        vehicles: [Vehicle!]
+      }
+
+      union Vehicle = NormalCar | Lorry | Bike
+
+      type NormalCar {
+        numberOfPassengers: Int
+        model: String
+      }
+
+      type Lorry {
+        maxLoad: Float
+        model: String
+      }
+
+      type Bike {
+        numberOfWheels: Int!
+      }
+      "
+    `)
+  })
+
   it('should compile string literals as enum', async () => {
     const graphql = await compileSchema({
       $schema: 'http://json-schema.org/draft-07/schema#',

--- a/src/graphqlGenerator.ts
+++ b/src/graphqlGenerator.ts
@@ -64,7 +64,7 @@ function declareNamedType(ast: ASTWithStandaloneName, types: TypeMap = new Map()
       if (isUnionOfStringLiterals(ast)) {
         return declareUnionOfStringLiteralsAsEnum(ast, types)
       }
-      return declareUnionType(ast, types)
+      return declareUnionType(flattenNestedUnions(ast), types)
     case 'ENUM':
       return declareEnumType(ast, types)
     case 'INTERSECTION':
@@ -189,6 +189,19 @@ function mergeIntersectionTypes(ast: TNamedIntersection): TNamedInterface {
     type: 'INTERFACE',
     superTypes: interfaces.flatMap((iast) => iast.superTypes),
     params: interfaces.flatMap((iast) => iast.params),
+  })
+}
+
+function flattenNestedUnions(ast: TNamedUnion): TNamedUnion {
+  const paramsWithFlattenedUnions = ast.params.flatMap((param) => {
+    if (param.type === 'UNION') {
+      return param.params
+    }
+    return [param]
+  })
+  return Object.assign(ast, {
+    type: 'UNION',
+    params: paramsWithFlattenedUnions,
   })
 }
 


### PR DESCRIPTION
Hey @split 👋🏻 A small addition to this fantastic tool.
Let me know if it makes sense or not.

With JSON schema, you can define a union member type as another union. But when generating GraphQL types, that _another_ union will be ignored.

Here's a simple use case that I used in the unit test.
There's a union `Vehicle`, which can be `Car` or `Bike`, and `Car` is also a union which can be `NormalCar` or `Lorry`. So basically, union `Vehicle` can be `NormalCar`, `Lorry` or `Bike`. For now, the generated GraphQL type will be `union Vehicle = Bike`, `NormalCar` and `Lorry` are ignored. With this change generated GraphQL type will be `union Vehicle = NormalCar | Lorry | Bike`.

I know that we can define `Vehicle` as `oneOf: [{ $ref: '#/$defs/normalCar' }, { $ref: '#/$defs/lorry' }, { $ref: '#/$defs/bike' }]`, and everything would work fine. But sometimes it might be useful to group unions (eg, in a separate json file).

What do you think about this? 🤔 